### PR TITLE
Feature - User Profiles List View

### DIFF
--- a/client/src/components/ApplicationViews.jsx
+++ b/client/src/components/ApplicationViews.jsx
@@ -3,6 +3,7 @@ import { AuthorizedRoute } from "./auth/AuthorizedRoute";
 import Login from "./auth/Login";
 import Register from "./auth/Register";
 import Home from "./Home.jsx";
+import UserProfilesList from "./userprofiles/UserProfilesList.jsx";
 
 export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
   return (
@@ -16,14 +17,16 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
             </AuthorizedRoute>
           }
         />
-        <Route
-          path="employees"
-          element={
-            <AuthorizedRoute roles={["Admin"]} loggedInUser={loggedInUser}>
-              <>User Profiles List</>
-            </AuthorizedRoute>
-          }
-        />
+        <Route path="userprofiles">
+          <Route 
+            index 
+            element={
+              <AuthorizedRoute roles={["Admin"]} loggedInUser={loggedInUser}>
+                <UserProfilesList loggedInUser={loggedInUser} />
+              </AuthorizedRoute>
+            } 
+          />
+        </Route>
         <Route
           path="login"
           element={<Login setLoggedInUser={setLoggedInUser} />}

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -19,40 +19,46 @@ const toggleNavbar = () => setOpen(!open);
 
 return (
     <div>
-    <Navbar color="light" light fixed="true" expand="lg">
-        <NavbarBrand className="mr-auto" tag={RRNavLink} to="/">
-        🧹🧼House Rules
-        </NavbarBrand>
-        {loggedInUser ? (
-        <>
-            <NavbarToggler onClick={toggleNavbar} />
-            <Collapse isOpen={open} navbar>
-            <Nav navbar></Nav>
-            </Collapse>
-            <Button
-            color="primary"
-            onClick={(e) => {
-                e.preventDefault();
-                setOpen(false);
-                logout().then(() => {
-                setLoggedInUser(null);
-                setOpen(false);
-                });
-            }}
-            >
-            Logout
-            </Button>
-        </>
-        ) : (
-        <Nav navbar>
-            <NavItem>
-            <NavLink tag={RRNavLink} to="/login">
-                <Button color="primary">Login</Button>
-            </NavLink>
-            </NavItem>
-        </Nav>
-        )}
-    </Navbar>
+        <Navbar color="light" light fixed="true" expand="lg">
+            <NavbarBrand className="mr-auto" tag={RRNavLink} to="/">
+            🧹🧼House Rules
+            </NavbarBrand>
+            {loggedInUser ? (
+            <>
+                <NavbarToggler onClick={toggleNavbar} />
+                <Collapse isOpen={open} navbar>
+                <Nav navbar>
+                    {loggedInUser.roles.includes("Admin") && (
+                        <NavItem>
+                            <NavLink tag={RRNavLink} to={"/userprofiles"}>User Profiles</NavLink>
+                        </NavItem>
+                    )}
+                </Nav>
+                </Collapse>
+                <Button
+                color="primary"
+                onClick={(e) => {
+                    e.preventDefault();
+                    setOpen(false);
+                    logout().then(() => {
+                    setLoggedInUser(null);
+                    setOpen(false);
+                    });
+                }}
+                >
+                Logout
+                </Button>
+            </>
+            ) : (
+            <Nav navbar>
+                <NavItem>
+                <NavLink tag={RRNavLink} to="/login">
+                    <Button color="primary">Login</Button>
+                </NavLink>
+                </NavItem>
+            </Nav>
+            )}
+        </Navbar>
     </div>
 );
 }

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react"
+import { getUserProfiles } from "../../managers/userProfileManager.js"
+import { Card, CardBody, CardHeader, CardText, CardTitle } from "reactstrap"
+
+export const UserProfilesList = ({ loggedInUser }) => {
+    const [userProfiles, setUserProfiles] = useState([])
+
+    useEffect(() => {
+        getUserProfiles().then(setUserProfiles)
+    }, [])
+    
+    return (
+        <div className="d-flex flex-column align-items-center gap-3 pt-3">
+            <div className="w-75">
+                <h1>User Profiles</h1>
+            </div>
+            {userProfiles.map(up => {
+                return (
+                    <Card className="w-75" key={`up-${up.id}`}>
+                        <CardHeader>
+                            <CardTitle className="fw-bold fs-2">
+                                {up.userName}
+                            </CardTitle>
+                            <CardText>
+                                {`${up.firstName} ${up.lastName}`}
+                            </CardText>
+                        </CardHeader>
+                        <CardBody>
+                            <CardText>
+                                {`Address: ${up.address}`}
+                            </CardText>
+                            <CardText>
+                                {`Email: ${up.email}`}
+                            </CardText>
+                        </CardBody>
+                    </Card>
+                )
+            })}
+        </div>
+    )
+}
+
+export default UserProfilesList

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -1,0 +1,5 @@
+const _apiUrl = "/api/userProfile"
+
+export const getUserProfiles = () => {
+    return fetch(_apiUrl).then(res => res.json())
+}


### PR DESCRIPTION
### Purpose
To allow logged in Users with the Admin Role to view a list of all User Profiles

### Files Changed
- Created file and added fetch for getting all User Profiles in new `userProfileManager.js`
- Created file and wrote initial rendering and logic for User Profiles List view in new `UserProfilesList.jsx` component module
- Added protected routing for User Profiles List view in `ApplicationViews.jsx`
- Added nav button to User Profiles List view that only renders for Admins in `NavBar.jsx`

### To Test
Fetch, setup, and run according to project readme, then confirm the following
- Nav button "User Profiles" renders in the navbar when logged in as an Admin
- Nav button "User Profiles" does NOT render in the navbar when logged in as a User without the Admin Role
- Clicking on the "User Profiles" button in the navbar navigates to the User Profiles List view
- Attempting to navigate to the User Profiles List view when not logged in as an Admin redirects User to the login page
- All User Profiles are rendered in the User Profiles List view

closes #4